### PR TITLE
Update runCommand function signature to match cmd rework and document resInfo object

### DIFF
--- a/Client/SDK.ts
+++ b/Client/SDK.ts
@@ -1,4 +1,6 @@
-import { Proxy, getBotsResponse } from "./types/returnTypes";
+import { Proxy, getBotsResponse } from "./types/ReturnTypes";
+import { resInfo } from "./types/ResInfoObj";
+
 class AbstractRPC {
   static ClassName = "";
   static async _generateMethodCall(
@@ -82,8 +84,8 @@ export class Settings extends AbstractRPC {
 
 export class Comments extends AbstractRPC {
   static ClassName = "Comment";
-  public static async comment(count: string, steamID: string) {
-    return await this._generateMethodCall("comment", { count, steamID });
+  public static async comment(count: string, steamID: string, resInfo: resInfo) {
+    return await this._generateMethodCall("comment", { count, steamID, resInfo });
   }
   public static async commentCount() {
     return await this._generateMethodCall("commentCount", {});
@@ -115,7 +117,7 @@ export class Commands extends AbstractRPC {
   public static async getCommandList() {
     return await this._generateMethodCall("getCommandList", {});
   }
-  public static async executeCommand(command: string, args: any[]) {
-    return await this._generateMethodCall("executeCommand", { command, args });
+  public static async executeCommand(command: string, args: any[], resInfo: resInfo) {
+    return await this._generateMethodCall("executeCommand", { command, args, resInfo });
   }
 }

--- a/Client/types/ResInfoObj.ts
+++ b/Client/types/ResInfoObj.ts
@@ -1,0 +1,39 @@
+/**
+ * Documentation of the default/commonly used content the resInfo object can/should contain
+ */
+export type resInfo = {
+    /**
+     * Prefix your command execution handler uses. This will be used in response messages referencing commands. Default: !
+     */
+    cmdprefix?: string;
+
+    /**
+     * ID of the user who executed this command. Will be used for command default behavior (e.g. commenting on the requester's profile), to check for owner privileges, apply cooldowns and maybe your respondModule implementation for responding. Strongly advised to include.
+     */
+    userID: string;
+
+    /**
+     * Can be provided to overwrite `config.ownerid` for owner privilege checks. Useful if you are implementing a different platform and so `userID` won't be a steamID64 (e.g. discord)
+     */
+    ownerIDs?: string[];
+
+    /**
+     * Supported by the Steam Chat Message handler: Overwrites the default index from which response messages will be cut up into parts
+     */
+    charLimit?: number;
+
+    /**
+     * Custom chars to search after for cutting string in parts to overwrite cutStringsIntelligently's default: [" ", "\n", "\r"]
+     */
+    cutChars?: string[];
+
+    /**
+     * Set to true if your command handler is receiving messages from the Steam Chat and `userID` is therefore a `steamID64`. Will be used to enable command default behavior (e.g. commenting on the requester's profile)
+     */
+    fromSteamChat?: boolean;
+
+    /**
+     * Do not provide this argument, you'll receive it from commands: Steam Chat Message prefixes like /me. Can be ignored or translated to similar prefixes your platform might support
+     */
+    prefix?: string;
+};

--- a/src/RPCHandlers/Commands.ts
+++ b/src/RPCHandlers/Commands.ts
@@ -1,5 +1,6 @@
 import { CommandDescription, commands } from "../schemes/commands";
 import { RPCReturnType } from "../types/PluginTypes";
+import { resInfo } from "../types/ResInfoObj";
 
 export class Commands {
   constructor(
@@ -18,8 +19,9 @@ export class Commands {
   executeCommand(params: {
     command: string;
     args: string[];
+    resInfo: resInfo;
   }): RPCReturnType<string> {
-    const { command, args } = params;
+    const { command, args, resInfo } = params;
     const needsArgs = commands.find((c) => c.name === command)?.args.length;
     if (!command || (needsArgs && !args)) {
       return {
@@ -38,13 +40,12 @@ export class Commands {
       this.commandHandler.runCommand(
         command,
         args,
-        this.controller.data.cachefile.ownerid[0],
         (context, infoData, data) => {
           console.log(data);
           info = data;
         },
         this,
-        {}
+        resInfo
       );
       return {
         status: 200,

--- a/src/RPCHandlers/Comment.ts
+++ b/src/RPCHandlers/Comment.ts
@@ -1,4 +1,5 @@
 import { RPCReturnType } from "../types/PluginTypes";
+import { resInfo } from "../types/ResInfoObj";
 
 export class CommentHandler {
   constructor(
@@ -8,8 +9,8 @@ export class CommentHandler {
     this.commandHandler = commandHandler;
     this.controller = controller;
   }
-  comment(params: { count: string; steamID: string }): RPCReturnType<string> {
-    const { count, steamID } = params;
+  comment(params: { count: string; steamID: string, resInfo: resInfo }): RPCReturnType<string> {
+    const { count, steamID, resInfo } = params;
     if (!count || !steamID) {
       return {
         status: 400,
@@ -20,10 +21,9 @@ export class CommentHandler {
     this.commandHandler.runCommand(
       "comment",
       [count, steamID],
-      steamID,
       () => {},
       this,
-      {}
+      resInfo
     );
     return {
       status: 200,

--- a/src/types/ResInfoObj.ts
+++ b/src/types/ResInfoObj.ts
@@ -1,0 +1,39 @@
+/**
+ * Documentation of the default/commonly used content the resInfo object can/should contain
+ */
+export type resInfo = {
+    /**
+     * Prefix your command execution handler uses. This will be used in response messages referencing commands. Default: !
+     */
+    cmdprefix?: string;
+
+    /**
+     * ID of the user who executed this command. Will be used for command default behavior (e.g. commenting on the requester's profile), to check for owner privileges, apply cooldowns and maybe your respondModule implementation for responding. Strongly advised to include.
+     */
+    userID: string;
+
+    /**
+     * Can be provided to overwrite `config.ownerid` for owner privilege checks. Useful if you are implementing a different platform and so `userID` won't be a steamID64 (e.g. discord)
+     */
+    ownerIDs?: string[];
+
+    /**
+     * Supported by the Steam Chat Message handler: Overwrites the default index from which response messages will be cut up into parts
+     */
+    charLimit?: number;
+
+    /**
+     * Custom chars to search after for cutting string in parts to overwrite cutStringsIntelligently's default: [" ", "\n", "\r"]
+     */
+    cutChars?: string[];
+
+    /**
+     * Set to true if your command handler is receiving messages from the Steam Chat and `userID` is therefore a `steamID64`. Will be used to enable command default behavior (e.g. commenting on the requester's profile)
+     */
+    fromSteamChat?: boolean;
+
+    /**
+     * Do not provide this argument, you'll receive it from commands: Steam Chat Message prefixes like /me. Can be ignored or translated to similar prefixes your platform might support
+     */
+    prefix?: string;
+};

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -1,3 +1,5 @@
+declare function logger(type: string, message: string): void;
+
 /**
  * Constructor - Initializes an object which represents a user steam account
  * @param controller - Reference to the controller object
@@ -399,6 +401,10 @@ declare class Controller {
      * The commandHandler object
      */
     commandHandler: CommandHandler;
+    /**
+     * Reference to the controller object
+     */
+    data: DataManager;
     /**
      * The pluginSystem handler
      */

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -1,217 +1,240 @@
-declare function logger(type: string, message: string): void;
-
 /**
  * Constructor - Initializes an object which represents a user steam account
  * @param controller - Reference to the controller object
  * @param index - The index of this account in the logininfo object
  */
 declare class Bot {
-  constructor(controller: Controller, index: number);
-  /**
-   * Reference to the controller object
-   */
-  controller: Controller;
-  /**
-   * Reference to the controller object
-   */
-  data: DataManager;
-  /**
-   * Login index of this bot account
-   */
-  index: number;
-  /**
-   * Status of this bot account
-   */
-  status: EStatus;
-  /**
-   * SteamID64's to ignore in the friendMessage event handler. This is used by readChatMessage() to prevent duplicate responses.
-   */
-  friendMessageBlock: string[];
-  /**
-   * Additional login related information for this bot account
-   */
-  loginData: any;
-  /**
-   * Calls SteamUser logOn() for this account. This will either trigger the SteamUser loggedOn or error event.
-   */
-  _loginToSteam(): void;
-  /**
-   * Checks if user is blocked, has an active cooldown for spamming or isn't a friend
-   * @param steamID64 - The steamID64 of the message sender
-   * @param message - The message string provided by steam-user friendMessage event
-   * @returns `true` if friendMessage event shouldn't be handled, `false` if user is allowed to be handled
-   */
-  checkMsgBlock(steamID64: any, message: string): boolean;
-  /**
-   * Our commandHandler respondModule implementation - Sends a message to a Steam user
-   * @param _this - The Bot object context
-   * @param resInfo - Object containing information passed to command by friendMessage event
-   * @param txt - The text to send
-   * @param retry - Internal: true if this message called itself again to send failure message
-   * @param part - Internal: Index of which part to send for messages larger than 750 chars
-   */
-  sendChatMessage(
-    _this: any,
-    resInfo: any,
-    txt: string,
-    retry: boolean,
-    part: number
-  ): void;
-  /**
-   * Waits for a Steam Chat message from this user to this account and resolves their message content. The "normal" friendMessage event handler will be blocked for this user.
-   * @param steamID64 - The steamID64 of the user to read a message from
-   * @param timeout - Time in ms after which the Promise will be resolved if user does not respond. Pass 0 to disable (not recommended)
-   * @returns Resolved with `String` on response or `null` on timeout.
-   */
-  readChatMessage(steamID64: string, timeout: number): Promise<string | null>;
-  /**
-   * Handles the SteamUser debug events if enabled in advancedconfig
-   */
-  _attachSteamDebugEvent(): void;
-  /**
-   * Handles the SteamUser disconnect event and tries to relog the account
-   */
-  _attachSteamDisconnectedEvent(): void;
-  /**
-   * Handles the SteamUser error event
-   */
-  _attachSteamErrorEvent(): void;
-  /**
-   * Handles messages, cooldowns and executes commands.
-   */
-  _attachSteamFriendMessageEvent(): void;
-  /**
-   * Do some stuff when account is logged in
-   */
-  _attachSteamLoggedOnEvent(): void;
-  /**
-   * Handles the SteamUser ownershipCached event and tries to redeem licenses for games the account is missing
-   */
-  _attachSteamOwnershipCachedEvent(): void;
-  /**
-   * Accepts a friend request, adds the user to the lastcomment.db database and invites him to your group
-   */
-  _attachSteamFriendRelationshipEvent(): void;
-  /**
-   * Accepts a group invite if acceptgroupinvites in the config is true
-   */
-  _attachSteamGroupRelationshipEvent(): void;
-  /**
-   * Handles setting cookies and accepting offline friend & group invites
-   */
-  _attachSteamWebSessionEvent(): void;
-  /**
-   * Checks if user is blocked, has an active cooldown for spamming or isn't a friend
-   * @param steamID64 - The steamID64 of the message sender
-   * @param message - The message string provided by steam-user friendMessage event
-   * @returns `true` if friendMessage event shouldn't be handled, `false` if user is allowed to be handled
-   */
-  checkMsgBlock(steamID64: any, message: string): boolean;
-  /**
-   * Handles aborting a login attempt should an account get stuck to prevent the bot from softlocking (see issue #139)
-   */
-  handleLoginTimeout(): void;
-  /**
-   * Our commandHandler respondModule implementation - Sends a message to a Steam user
-   * @param _this - The Bot object context
-   * @param resInfo - Object containing information passed to command by friendMessage event
-   * @param txt - The text to send
-   * @param retry - Internal: true if this message called itself again to send failure message
-   * @param part - Internal: Index of which part to send for messages larger than 750 chars
-   */
-  sendChatMessage(
-    _this: any,
-    resInfo: any,
-    txt: string,
-    retry: boolean,
-    part: number
-  ): void;
-  /**
-   * Waits for a Steam Chat message from this user to this account and resolves their message content. The "normal" friendMessage event handler will be blocked for this user.
-   * @param steamID64 - The steamID64 of the user to read a message from
-   * @param timeout - Time in ms after which the Promise will be resolved if user does not respond. Pass 0 to disable (not recommended)
-   * @returns Resolved with `String` on response or `null` on timeout.
-   */
-  readChatMessage(steamID64: string, timeout: number): Promise<string | null>;
+    constructor(controller: Controller, index: number);
+    /**
+     * Reference to the controller object
+     */
+    controller: Controller;
+    /**
+     * Reference to the controller object
+     */
+    data: DataManager;
+    /**
+     * Login index of this bot account
+     */
+    index: number;
+    /**
+     * Status of this bot account
+     */
+    status: EStatus;
+    /**
+     * SteamID64's to ignore in the friendMessage event handler. This is used by readChatMessage() to prevent duplicate responses.
+     */
+    friendMessageBlock: string[];
+    /**
+     * Additional login related information for this bot account
+     */
+    loginData: any;
+    /**
+     * Calls SteamUser logOn() for this account. This will either trigger the SteamUser loggedOn or error event.
+     */
+    _loginToSteam(): void;
+    /**
+     * Checks if user is blocked, has an active cooldown for spamming or isn't a friend
+     * @param steamID64 - The steamID64 of the message sender
+     * @param message - The message string provided by steam-user friendMessage event
+     * @returns `true` if friendMessage event shouldn't be handled, `false` if user is allowed to be handled
+     */
+    checkMsgBlock(steamID64: any, message: string): boolean;
+    /**
+     * Handles aborting a login attempt should an account get stuck to prevent the bot from softlocking (see issue #139)
+     */
+    handleLoginTimeout(): void;
+    /**
+     * Handles checking for missing game licenses, requests them and then starts playing
+     */
+    handleMissingGameLicenses(): void;
+    /**
+     * Our commandHandler respondModule implementation - Sends a message to a Steam user
+     * @param _this - The Bot object context
+     * @param txt - The text to send
+     * @param retry - Internal: true if this message called itself again to send failure message
+     * @param part - Internal: Index of which part to send for messages larger than 750 chars
+     */
+    sendChatMessage(_this: any, resInfo: any, txt: string, retry: boolean, part: number): void;
+    /**
+     * Waits for a Steam Chat message from this user to this account and resolves their message content. The "normal" friendMessage event handler will be blocked for this user.
+     * @param steamID64 - The steamID64 of the user to read a message from
+     * @param timeout - Time in ms after which the Promise will be resolved if user does not respond. Pass 0 to disable (not recommended)
+     * @returns Resolved with `String` on response or `null` on timeout.
+     */
+    readChatMessage(steamID64: string, timeout: number): Promise<string | null>;
+    /**
+     * Handles the SteamUser debug events if enabled in advancedconfig
+     */
+    _attachSteamDebugEvent(): void;
+    /**
+     * Handles the SteamUser disconnect event and tries to relog the account
+     */
+    _attachSteamDisconnectedEvent(): void;
+    /**
+     * Handles the SteamUser error event
+     */
+    _attachSteamErrorEvent(): void;
+    /**
+     * Handles messages, cooldowns and executes commands.
+     */
+    _attachSteamFriendMessageEvent(): void;
+    /**
+     * Do some stuff when account is logged in
+     */
+    _attachSteamLoggedOnEvent(): void;
+    /**
+     * Accepts a friend request, adds the user to the lastcomment.db database and invites him to your group
+     */
+    _attachSteamFriendRelationshipEvent(): void;
+    /**
+     * Accepts a group invite if acceptgroupinvites in the config is true
+     */
+    _attachSteamGroupRelationshipEvent(): void;
+    /**
+     * Handles setting cookies and accepting offline friend & group invites
+     */
+    _attachSteamWebSessionEvent(): void;
+    /**
+     * Checks if user is blocked, has an active cooldown for spamming or isn't a friend
+     * @param steamID64 - The steamID64 of the message sender
+     * @param message - The message string provided by steam-user friendMessage event
+     * @returns `true` if friendMessage event shouldn't be handled, `false` if user is allowed to be handled
+     */
+    checkMsgBlock(steamID64: any, message: string): boolean;
+    /**
+     * Handles aborting a login attempt should an account get stuck to prevent the bot from softlocking (see issue #139)
+     */
+    handleLoginTimeout(): void;
+    /**
+     * Handles checking for missing game licenses, requests them and then starts playing
+     */
+    handleMissingGameLicenses(): void;
+    /**
+     * Our commandHandler respondModule implementation - Sends a message to a Steam user
+     * @param _this - The Bot object context
+     * @param txt - The text to send
+     * @param retry - Internal: true if this message called itself again to send failure message
+     * @param part - Internal: Index of which part to send for messages larger than 750 chars
+     */
+    sendChatMessage(_this: any, resInfo: any, txt: string, retry: boolean, part: number): void;
+    /**
+     * Waits for a Steam Chat message from this user to this account and resolves their message content. The "normal" friendMessage event handler will be blocked for this user.
+     * @param steamID64 - The steamID64 of the user to read a message from
+     * @param timeout - Time in ms after which the Promise will be resolved if user does not respond. Pass 0 to disable (not recommended)
+     * @returns Resolved with `String` on response or `null` on timeout.
+     */
+    readChatMessage(steamID64: string, timeout: number): Promise<string | null>;
 }
 
 declare namespace Bot {
-  /**
-   * Status which a bot object can have
-   */
-  enum EStatus {}
+    /**
+     * Status which a bot object can have
+     */
+    enum EStatus {
+    }
 }
+
+/**
+ * @property description - Description of what this command does
+ * @property args - Array of objects containing information about each parameter supported by this command
+ * @property ownersOnly - Set to true to only allow owners to use this command.
+ * @property run - Function that will be executed when the command runs. Arguments: commandHandler, args, steamID64, respondModule, context, resInfo
+ */
+declare type Command = {
+    description: string;
+    args: CommandArg[];
+    ownersOnly: boolean;
+    run: (...params: any[]) => any;
+};
+
+/**
+ * @property name - Name of this argument. Use common phrases like "ID" or "amount" if possible. If a specific word is expected, put the word inside quotation marks.
+ * @property description - Description of this argument
+ * @property type - Expected datatype of this argument. If read from a chat it will usually be "string"
+ * @property isOptional - True if this argument is optional, false if it must be provided. Make sure to check for missing arguments and return an error if false.
+ * @property ownersOnly - True if this argument is only allowed to be provided by owners set in the config. If the command itself is `ownersOnly`, set this property to `true` as well.
+ */
+declare type CommandArg = {
+    name: string;
+    description: string;
+    type: string;
+    isOptional: boolean;
+    ownersOnly: boolean;
+};
 
 /**
  * Constructor - Initializes the commandHandler which allows you to integrate core commands into your plugin or add new commands from your plugin.
  * @param controller - Reference to the current controller object
  */
 declare class CommandHandler {
-  constructor(controller: Controller);
-  /**
-   * Internal: Imports core commands on startup
-   */
-  _importCoreCommands(): void;
-  /**
-   * Registers a new command during runtime
-   * @param command - The command object to register
-   * @param command.description - Description of what this command does
-   * @param command.ownersOnly - Set to true to only allow owners to use this command.
-   * @param command.run - Function that will be executed when the command runs. Arguments: commandHandler, args, steamID64, respondModule, context, resInfo
-   * @returns true if the command was successfully registered, false otherwise
-   */
-  registerCommand(command: {
-    description: string;
-    ownersOnly: boolean;
-    run: (...params: any[]) => any;
-  }): any;
-  /**
-   * The name of the command to unregister during runtime
-   * @param commandName - Name of the command to unregister
-   * @returns true if the command was successfully unregistered, false otherwise
-   */
-  unregisterCommand(commandName: string): any;
-  /**
-   * Finds a loaded command by name and runs it
-   * @param name - The name of the command
-   * @param args - Array of arguments that will be passed to the command
-   * @param steamID64 - SteamID64 of the requesting user which is used to check for ownerOnly and will be passed to the command
-   * @param respondModule - Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
-   * @param context - The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-   * @param resInfo - Object containing additional information your respondModule might need to process the response (for example the userID who executed the command). Please also include a "cmdprefix" key & value pair if your command handler uses a prefix other than "!".
-   * @returns `true` if command was found, `false` if not
-   */
-  runCommand(
-    name: string,
-    args: any[],
-    steamID64: string,
-    respondModule: (...params: any[]) => any,
-    context: any,
-    resInfo: any
-  ): any;
-  /**
-   * Reloads all core commands. Does NOT reload commands registered at runtime. Please consider reloading the pluginSystem as well.
-   */
-  reloadCommands(): void;
+    constructor(controller: Controller);
+    /**
+     * Array of objects, where each object represents a registered command
+     */
+    commands: Command[];
+    /**
+     * Internal: Imports core commands on startup
+     * @returns Resolved when all commands have been imported
+     */
+    _importCoreCommands(): Promise<void>;
+    /**
+     * Registers a new command during runtime
+     * @param command - The command object to register
+     * @returns true if the command was successfully registered, false otherwise
+     */
+    registerCommand(command: Command): boolean;
+    /**
+     * The name of the command to unregister during runtime
+     * @param commandName - Name of the command to unregister
+     * @returns `true` if the command was successfully unregistered, `false` otherwise
+     */
+    unregisterCommand(commandName: string): boolean;
+    /**
+     * Finds a loaded command by name and runs it
+     * @param name - The name of the command
+     * @param args - Array of arguments that will be passed to the command
+     * @param respondModule - Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
+     * @param context - The context (`this.`) of the object calling this command. Will be passed to respondModule() as first parameter to make working in this function easier.
+     * @param resInfo - Object containing additional information
+     * @returns `true` if command was found, `false` if not
+     */
+    runCommand(name: string, args: any[], respondModule: (...params: any[]) => any, context: any, resInfo: resInfo): boolean;
+    /**
+     * Reloads all core commands. Does NOT reload commands registered at runtime. Please consider reloading the pluginSystem as well.
+     */
+    reloadCommands(): void;
 }
+
+/**
+ * @property [cmdprefix] - Prefix your command execution handler uses. This will be used in response messages referencing commands. Default: !
+ * @property userID - ID of the user who executed this command. Will be used for command default behavior (e.g. commenting on the requester's profile), to check for owner privileges, apply cooldowns and maybe your respondModule implementation for responding. Strongly advised to include.
+ * @property [ownerIDs] - Can be provided to overwrite `config.ownerid` for owner privilege checks. Useful if you are implementing a different platform and so `userID` won't be a steamID64 (e.g. discord)
+ * @property [charLimit] - Supported by the Steam Chat Message handler: Overwrites the default index from which response messages will be cut up into parts
+ * @property [cutChars] - Custom chars to search after for cutting string in parts to overwrite cutStringsIntelligently's default: [" ", "\n", "\r"]
+ * @property [fromSteamChat] - Set to true if your command handler is receiving messages from the Steam Chat and `userID` is therefore a `steamID64`. Will be used to enable command default behavior (e.g. commenting on the requester's profile)
+ * @property [prefix] - Do not provide this argument, you'll receive it from commands: Steam Chat Message prefixes like /me. Can be ignored or translated to similar prefixes your platform might support
+ */
+declare type resInfo = {
+    cmdprefix?: string;
+    userID: string;
+    ownerIDs?: string[];
+    charLimit?: number;
+    cutChars?: string[];
+    fromSteamChat?: boolean;
+    prefix?: string;
+};
 
 /**
  * Internal: Do the actual commenting, activeRequests entry with all relevant information was processed by the comment command function above.
  * @param commandHandler - The commandHandler object
  * @param resInfo - Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
- * @param respond - Shortened respondModule call
+ * @param respond - The shortened respondModule call
  * @param postComment - The correct postComment function for this idType. Context from the correct bot account is being applied later.
  * @param commentArgs - All arguments this postComment function needs, without callback. It will be applied and a callback added as last param. Include a key called "quote" to dynamically replace it with a random quote.
  * @param receiverSteamID64 - steamID64 of the profile to receive the comments
  */
-declare function comment(
-  commandHandler: CommandHandler,
-  resInfo: any,
-  respond: (...params: any[]) => any,
-  postComment: (...params: any[]) => any,
-  commentArgs: any,
-  receiverSteamID64: string
-): void;
+declare function comment(commandHandler: CommandHandler, resInfo: CommandHandler.resInfo, respond: (...params: any[]) => any, postComment: (...params: any[]) => any, commentArgs: any, receiverSteamID64: string): void;
 
 /**
  * Retrieves arguments from a comment request. If request is invalid (for example too many comments requested) an error message will be sent
@@ -219,22 +242,10 @@ declare function comment(
  * @param args - The command arguments
  * @param requesterSteamID64 - The steamID64 of the requesting user
  * @param resInfo - Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
- * @param respond - The function to send messages to the requesting user
+ * @param respond - The shortened respondModule call
+ * @returns Resolves promise with object containing all relevant data when done
  */
-declare function getCommentArgs(
-  commandHandler: CommandHandler,
-  args: any[],
-  requesterSteamID64: string,
-  resInfo: any,
-  respond: (...params: any[]) => any
-): Promise<{
-  maxRequestAmount: number;
-  commentcmdUsage: string;
-  numberOfComments: number;
-  profileID: string;
-  idType: string;
-  quotesArr: string[];
-}>;
+declare function getCommentArgs(commandHandler: CommandHandler, args: any[], requesterSteamID64: string, resInfo: CommandHandler.resInfo, respond: (...params: any[]) => any): Promise<{ maxRequestAmount: number; commentcmdUsage: string; numberOfComments: number; profileID: string; idType: string; quotesArr: string[]; }>;
 
 /**
  * Finds all needed and currently available bot accounts for a comment request.
@@ -245,13 +256,7 @@ declare function getCommentArgs(
  * @param receiverSteamID - Optional: steamID64 of the receiving user. If set, accounts that are friend with the user will be prioritized and accsToAdd will be calculated.
  * @returns `availableAccounts` contains all account names from bot object, `accsToAdd` account names which are limited and not friend, `whenAvailable` is a timestamp representing how long to wait until accsNeeded accounts will be available and `whenAvailableStr` is formatted human-readable as time from now
  */
-declare function getAvailableBotsForCommenting(
-  commandHandler: CommandHandler,
-  numberOfComments: number,
-  canBeLimited: boolean,
-  idType: string,
-  receiverSteamID: string
-): any;
+declare function getAvailableBotsForCommenting(commandHandler: CommandHandler, numberOfComments: number, canBeLimited: boolean, idType: string, receiverSteamID: string): any;
 
 /**
  * Finds all needed and currently available bot accounts for a favorite request.
@@ -259,19 +264,9 @@ declare function getAvailableBotsForCommenting(
  * @param amount - Amount of favs requested or "all" to get the max available amount
  * @param id - The sharedfile id to favorize
  * @param favType - Either "favorite" or "unfavorite", depending on which request this is
- * @returns Promise with obj: `availableAccounts` contains all account names from bot object, `whenAvailable` is a timestamp representing how long to wait until accsNeeded accounts will be available and `whenAvailableStr` is formatted human-readable as time from now
+ * @returns Resolves with obj: `availableAccounts` contains all account names from bot object, `whenAvailable` is a timestamp representing how long to wait until accsNeeded accounts will be available and `whenAvailableStr` is formatted human-readable as time from now
  */
-declare function getAvailableBotsForFavorizing(
-  commandHandler: CommandHandler,
-  amount: number | "all",
-  id: string,
-  favType: string
-): Promise<{
-  amount: number;
-  availableAccounts: string[];
-  whenAvailable: number;
-  whenAvailableStr: string;
-}>;
+declare function getAvailableBotsForFavorizing(commandHandler: CommandHandler, amount: number | "all", id: string, favType: string): Promise<{ amount: number; availableAccounts: string[]; whenAvailable: number; whenAvailableStr: string; }>;
 
 /**
  * Retrieves arguments from a vote request. If request is invalid, an error message will be sent
@@ -279,16 +274,10 @@ declare function getAvailableBotsForFavorizing(
  * @param args - The command arguments
  * @param cmd - Either "upvote", "downvote", "favorite" or "unfavorite", depending on which command is calling this function
  * @param resInfo - Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
- * @param respond - The function to send messages to the requesting user
+ * @param respond - The shortened respondModule call
  * @returns If the user provided a specific amount, amount will be a number. If user provided "all" or "max", it will be returned as an unmodified string for getVoteBots.js to handle
  */
-declare function getSharedfileArgs(
-  commandHandler: CommandHandler,
-  args: any[],
-  cmd: string,
-  resInfo: any,
-  respond: (...params: any[]) => any
-): Promise<{ amount: number | string; id: string }>;
+declare function getSharedfileArgs(commandHandler: CommandHandler, args: any[], cmd: string, resInfo: CommandHandler.resInfo, respond: (...params: any[]) => any): Promise<{ amount: number | string; id: string; }>;
 
 /**
  * Finds all needed and currently available bot accounts for a vote request.
@@ -296,19 +285,9 @@ declare function getSharedfileArgs(
  * @param amount - Amount of votes requested or "all" to get the max available amount
  * @param id - The sharedfile id to vote on
  * @param voteType - "upvote" or "downvote", depending on which request this is
- * @returns Promise with obj: `availableAccounts` contains all account names from bot object, `whenAvailable` is a timestamp representing how long to wait until accsNeeded accounts will be available and `whenAvailableStr` is formatted human-readable as time from now
+ * @returns Resolves with obj: `availableAccounts` contains all account names from bot object, `whenAvailable` is a timestamp representing how long to wait until accsNeeded accounts will be available and `whenAvailableStr` is formatted human-readable as time from now
  */
-declare function getAvailableBotsForVoting(
-  commandHandler: CommandHandler,
-  amount: number | "all",
-  id: string,
-  voteType: string
-): Promise<{
-  amount: number;
-  availableAccounts: string[];
-  whenAvailable: number;
-  whenAvailableStr: string;
-}>;
+declare function getAvailableBotsForVoting(commandHandler: CommandHandler, amount: number | "all", id: string, voteType: string): Promise<{ amount: number; availableAccounts: string[]; whenAvailable: number; whenAvailableStr: string; }>;
 
 /**
  * Checks if the following comment process iteration should be skipped
@@ -319,12 +298,7 @@ declare function getAvailableBotsForVoting(
  * @param receiverSteamID64 - steamID64 of the receiving user/group
  * @returns true if iteration should continue, false if iteration should be skipped using return
  */
-declare function handleIterationSkip(
-  commandHandler: CommandHandler,
-  loop: any,
-  bot: Bot,
-  receiverSteamID64: string
-): boolean;
+declare function handleIterationSkip(commandHandler: CommandHandler, loop: any, bot: Bot, receiverSteamID64: string): boolean;
 
 /**
  * Adds a description to comment errors and applies additional cooldowns for certain errors
@@ -333,12 +307,7 @@ declare function handleIterationSkip(
  * @param bot - Bot object of the account posting this comment
  * @param receiverSteamID64 - steamID64 of the receiving user/group
  */
-declare function logCommentError(
-  error: string,
-  commandHandler: CommandHandler,
-  bot: Bot,
-  receiverSteamID64: string
-): void;
+declare function logCommentError(error: string, commandHandler: CommandHandler, bot: Bot, receiverSteamID64: string): void;
 
 /**
  * Helper function to sort failed object by comment number so that it is easier to read
@@ -354,18 +323,33 @@ declare function sortFailedCommentsObject(failedObj: any): void;
 declare function failedCommentsObjToString(obj: any): string;
 
 /**
+ * Checks if the following vote process iteration should be skipped
+ * @param commandHandler - The commandHandler object
+ * @param loop - Object returned by misc.js syncLoop() helper
+ * @param bot - Bot object of the account making this request
+ * @param id - ID of the sharedfile that receives the votes
+ * @returns `true` if iteration should continue, `false` if iteration should be skipped using return
+ */
+declare function handleVoteIterationSkip(commandHandler: CommandHandler, loop: any, bot: Bot, id: string): boolean;
+
+/**
+ * Checks if the following favorite process iteration should be skipped
+ * @param commandHandler - The commandHandler object
+ * @param loop - Object returned by misc.js syncLoop() helper
+ * @param bot - Bot object of the account making this request
+ * @param id - ID of the sharedfile that receives the votes
+ * @returns `true` if iteration should continue, `false` if iteration should be skipped using return
+ */
+declare function handleFavoriteIterationSkip(commandHandler: CommandHandler, loop: any, bot: Bot, id: string): boolean;
+
+/**
  * Logs vote errors
  * @param error - The error string returned by steam-community
  * @param commandHandler - The commandHandler object
  * @param bot - Bot object of the account making this request
  * @param id - ID of the sharedfile that receives the votes
  */
-declare function logVoteError(
-  error: string,
-  commandHandler: CommandHandler,
-  bot: Bot,
-  id: string
-): void;
+declare function logVoteError(error: string, commandHandler: CommandHandler, bot: Bot, id: string): void;
 
 /**
  * Logs favorite errors
@@ -374,12 +358,7 @@ declare function logVoteError(
  * @param bot - Bot object of the account making this request
  * @param id - ID of the sharedfile that receives the favorites
  */
-declare function logFavoriteError(
-  error: string,
-  commandHandler: CommandHandler,
-  bot: Bot,
-  id: string
-): void;
+declare function logFavoriteError(error: string, commandHandler: CommandHandler, bot: Bot, id: string): void;
 
 /**
  * Helper function to sort failed object by comment number so that it is easier to read
@@ -391,229 +370,203 @@ declare function sortFailedCommentsObject(failedObj: any): void;
  * Constructor - Initializes the controller and starts all bot accounts
  */
 declare class Controller {
-  constructor();
-  /**
-   * Collection of miscellaneous functions for easier access
-   */
-  misc: any;
-  /**
-   * Internal: Inits the DataManager system, runs the updater and starts all bot accounts
-   */
-  _start(): void;
-  /**
-   * Internal: Loads all parts of the application to get IntelliSense support after the updater ran and calls login() when done.
-   */
-  _preLogin(): void;
-  /**
-   * The updater object
-   */
-  updater: Updater;
-  /**
-   * Stores references to all bot account objects mapped to their accountName
-   */
-  bots: {
-    [key: string]: Bot;
-  };
-  /**
-   * The main bot account
-   */
-  main: Bot;
-  /**
-   * The commandHandler object
-   */
-  commandHandler: CommandHandler;
-  data: DataManager;
-  /**
-   * The pluginSystem handler
-   */
-  pluginSystem: PluginSystem;
-  /**
-   * Restarts the whole application
-   * @param data - Stringified restartdata object that will be kept through restarts
-   */
-  restart(data: string): void;
-  /**
-   * Stops the whole application
-   */
-  stop(): void;
-  /**
-   * Attempts to log in all bot accounts which are currently offline one after another.
-   * Creates a new bot object for every new account and reuses existing one if possible
-   * @param firstLogin - Is set to true by controller if this is the first login to display more information
-   */
-  login(firstLogin: boolean): void;
-  /**
-   * Runs internal ready event code and emits ready event for plugins
-   */
-  _readyEvent(): void;
-  /**
-   * Runs internal statusUpdate event code and emits statusUpdate event for plugins
-   * @param bot - Bot instance
-   * @param newStatus - The new status
-   */
-  _statusUpdateEvent(bot: Bot, newStatus: Bot.EStatus): void;
-  /**
-   * Emits steamGuardInput event for bot & plugins
-   * @param bot - Bot instance of the affected account
-   * @param submitCode - Function to submit a code. Pass an empty string to skip the account.
-   */
-  _steamGuardInputEvent(bot: Bot, submitCode: (...params: any[]) => any): void;
-  /**
-   * Check if all friends are in lastcomment database
-   * @param bot - Bot object of the account to check
-   */
-  checkLastcommentDB(bot: Bot): void;
-  /**
-   * Checks the remaining space on the friendlist of a bot account, sends a warning message if it is less than 10 and force unfriends oldest lastcomment db user to always keep room for 1 friend.
-   * @param bot - Bot object of the account to check
-   * @param [callback] - Called with `remaining` (Number) on completion
-   */
-  friendListCapacityCheck(bot: Bot, callback?: (...params: any[]) => any): void;
-  /**
-   * Check for friends who haven't requested comments in config.unfriendtime days and unfriend them
-   */
-  _lastcommentUnfriendCheck(): void;
-  /**
-   * Retrieves all matching bot accounts and returns them.
-   * @param [statusFilter = EStatus.ONLINE] - Optional: EStatus or Array of EStatus's including account statuses to filter. Pass '*' to get all accounts. If omitted, only accs with status 'EStatus.ONLINE' will be returned.
-   * @param mapToObject - Optional: If true, an object will be returned where every bot object is mapped to their accountName.
-   * @returns An array or object if `mapToObject == true` containing all matching bot accounts.
-   */
-  getBots(
-    statusFilter?: EStatus | EStatus[] | string,
-    mapToObject: boolean
-  ): any[] | any;
-  /**
-   * Internal: Handles process's unhandledRejection & uncaughtException error events.
-   * Should a NPM related error be detected it attempts to reinstall all packages using our npminteraction helper function
-   */
-  _handleErrors(): void;
-  /**
-   * Handles converting URLs to steamIDs, determining their type if unknown and checking if it matches your expectation
-   * @param str - The profileID argument provided by the user
-   * @param expectedIdType - The type of SteamID expected ("profile", "group" or "sharedfile") or `null` if type should be assumed.
-   * @param [callback] - Called with `err` (String or null), `steamID64` (String or null), `idType` (String or null) parameters on completion
-   */
-  handleSteamIdResolving(
-    str: string,
-    expectedIdType: string,
-    callback?: (...params: any[]) => any
-  ): void;
-  /**
-   * Logs text to the terminal and appends it to the output.txt file.
-   * @param type - String that determines the type of the log message. Can be info, warn, error, debug or an empty string to not use the field.
-   * @param str - The text to log into the terminal
-   * @param nodate - Setting to true will hide date and time in the message
-   * @param remove - Setting to true will remove this message with the next one
-   * @param printNow - Ignores the readyafterlogs check and force prints the message now
-   */
-  logger(
-    type: string,
-    str: string,
-    nodate: boolean,
-    remove: boolean,
-    printNow: boolean
-  ): void;
-  /**
-   * Internal: Call this function after loading advancedconfig.json to set previously inaccessible options
-   */
-  _loggerOptionsUpdateAfterConfigLoad(): void;
-  /**
-   * Internal: Logs all held back messages from logAfterReady array
-   */
-  _loggerLogAfterReady(): void;
-  /**
-   * Runs internal ready event code and emits ready event for plugins
-   */
-  _readyEvent(): void;
-  /**
-   * Runs internal statusUpdate event code and emits statusUpdate event for plugins
-   * @param bot - Bot instance
-   * @param newStatus - The new status
-   */
-  _statusUpdateEvent(bot: Bot, newStatus: Bot.EStatus): void;
-  /**
-   * Emits steamGuardInput event for bot & plugins
-   * @param bot - Bot instance of the affected account
-   * @param submitCode - Function to submit a code. Pass an empty string to skip the account.
-   */
-  _steamGuardInputEvent(bot: Bot, submitCode: (...params: any[]) => any): void;
-  /**
-   * Check if all friends are in lastcomment database
-   * @param bot - Bot object of the account to check
-   */
-  checkLastcommentDB(bot: Bot): void;
-  /**
-   * Checks the remaining space on the friendlist of a bot account, sends a warning message if it is less than 10 and force unfriends oldest lastcomment db user to always keep room for 1 friend.
-   * @param bot - Bot object of the account to check
-   * @param [callback] - Called with `remaining` (Number) on completion
-   */
-  friendListCapacityCheck(bot: Bot, callback?: (...params: any[]) => any): void;
-  /**
-   * Check for friends who haven't requested comments in config.unfriendtime days and unfriend them
-   */
-  _lastcommentUnfriendCheck(): void;
-  /**
-   * Retrieves all matching bot accounts and returns them.
-   * @param [statusFilter = EStatus.ONLINE] - Optional: EStatus or Array of EStatus's including account statuses to filter. Pass '*' to get all accounts. If omitted, only accs with status 'EStatus.ONLINE' will be returned.
-   * @param mapToObject - Optional: If true, an object will be returned where every bot object is mapped to their accountName.
-   * @returns An array or object if `mapToObject == true` containing all matching bot accounts.
-   */
-  getBots(
-    statusFilter?: EStatus | EStatus[] | string,
-    mapToObject: boolean
-  ): any[] | any;
-  /**
-   * Internal: Handles process's unhandledRejection & uncaughtException error events.
-   * Should a NPM related error be detected it attempts to reinstall all packages using our npminteraction helper function
-   */
-  _handleErrors(): void;
-  /**
-   * Handles converting URLs to steamIDs, determining their type if unknown and checking if it matches your expectation
-   * @param str - The profileID argument provided by the user
-   * @param expectedIdType - The type of SteamID expected ("profile", "group" or "sharedfile") or `null` if type should be assumed.
-   * @param [callback] - Called with `err` (String or null), `steamID64` (String or null), `idType` (String or null) parameters on completion
-   */
-  handleSteamIdResolving(
-    str: string,
-    expectedIdType: string,
-    callback?: (...params: any[]) => any
-  ): void;
-  /**
-   * Logs text to the terminal and appends it to the output.txt file.
-   * @param type - String that determines the type of the log message. Can be info, warn, error, debug or an empty string to not use the field.
-   * @param str - The text to log into the terminal
-   * @param nodate - Setting to true will hide date and time in the message
-   * @param remove - Setting to true will remove this message with the next one
-   * @param printNow - Ignores the readyafterlogs check and force prints the message now
-   */
-  logger(
-    type: string,
-    str: string,
-    nodate: boolean,
-    remove: boolean,
-    printNow: boolean
-  ): void;
-  /**
-   * Internal: Call this function after loading advancedconfig.json to set previously inaccessible options
-   */
-  _loggerOptionsUpdateAfterConfigLoad(): void;
-  /**
-   * Internal: Logs all held back messages from logAfterReady array
-   */
-  _loggerLogAfterReady(): void;
-  /**
-   * Attempts to log in all bot accounts which are currently offline one after another.
-   * Creates a new bot object for every new account and reuses existing one if possible
-   * @param firstLogin - Is set to true by controller if this is the first login to display more information
-   */
-  login(firstLogin: boolean): void;
+    constructor();
+    /**
+     * Collection of miscellaneous functions for easier access
+     */
+    misc: any;
+    /**
+     * Internal: Inits the DataManager system, runs the updater and starts all bot accounts
+     */
+    _start(): void;
+    /**
+     * Internal: Loads all parts of the application to get IntelliSense support after the updater ran and calls login() when done.
+     */
+    _preLogin(): void;
+    /**
+     * The updater object
+     */
+    updater: Updater;
+    /**
+     * Stores references to all bot account objects mapped to their accountName
+     */
+    bots: any;
+    /**
+     * The main bot account
+     */
+    main: Bot;
+    /**
+     * The commandHandler object
+     */
+    commandHandler: CommandHandler;
+    /**
+     * The pluginSystem handler
+     */
+    pluginSystem: PluginSystem;
+    /**
+     * Restarts the whole application
+     * @param data - Stringified restartdata object that will be kept through restarts
+     */
+    restart(data: string): void;
+    /**
+     * Stops the whole application
+     */
+    stop(): void;
+    /**
+     * Attempts to log in all bot accounts which are currently offline one after another.
+     * Creates a new bot object for every new account and reuses existing one if possible
+     * @param firstLogin - Is set to true by controller if this is the first login to display more information
+     */
+    login(firstLogin: boolean): void;
+    /**
+     * Runs internal ready event code and emits ready event for plugins
+     */
+    _readyEvent(): void;
+    /**
+     * Runs internal statusUpdate event code and emits statusUpdate event for plugins
+     * @param bot - Bot instance
+     * @param newStatus - The new status of this bot
+     */
+    _statusUpdateEvent(bot: Bot, newStatus: Bot.EStatus): void;
+    /**
+     * Emits steamGuardInput event for bot & plugins
+     * @param bot - Bot instance of the affected account
+     * @param submitCode - Function to submit a code. Pass an empty string to skip the account.
+     */
+    _steamGuardInputEvent(bot: Bot, submitCode: (...params: any[]) => any): void;
+    /**
+     * Check if all friends are in lastcomment database
+     * @param bot - Bot object of the account to check
+     */
+    checkLastcommentDB(bot: Bot): void;
+    /**
+     * Checks the remaining space on the friendlist of a bot account, sends a warning message if it is less than 10 and force unfriends oldest lastcomment db user to always keep room for 1 friend.
+     * @param bot - Bot object of the account to check
+     */
+    friendListCapacityCheck(bot: Bot, callback: any): void;
+    /**
+     * Check for friends who haven't requested comments in config.unfriendtime days and unfriend them
+     */
+    _lastcommentUnfriendCheck(): void;
+    /**
+     * Retrieves all matching bot accounts and returns them.
+     * @param [statusFilter = EStatus.ONLINE] - Optional: EStatus or Array of EStatus's including account statuses to filter. Pass '*' to get all accounts. If omitted, only accs with status 'EStatus.ONLINE' will be returned.
+     * @param mapToObject - Optional: If true, an object will be returned where every bot object is mapped to their accountName.
+     * @returns An array or object if `mapToObject == true` containing all matching bot accounts.
+     */
+    getBots(statusFilter?: EStatus | EStatus[] | string, mapToObject: boolean): any[] | any;
+    /**
+     * Internal: Handles process's unhandledRejection & uncaughtException error events.
+     * Should a NPM related error be detected it attempts to reinstall all packages using our npminteraction helper function
+     */
+    _handleErrors(): void;
+    /**
+     * Handles converting URLs to steamIDs, determining their type if unknown and checking if it matches your expectation
+     * @param str - The profileID argument provided by the user
+     * @param expectedIdType - The type of SteamID expected ("profile", "group" or "sharedfile") or `null` if type should be assumed.
+     */
+    handleSteamIdResolving(str: string, expectedIdType: string, callback: any): void;
+    /**
+     * Logs text to the terminal and appends it to the output.txt file.
+     * @param type - String that determines the type of the log message. Can be info, warn, error, debug or an empty string to not use the field.
+     * @param str - The text to log into the terminal
+     * @param nodate - Setting to true will hide date and time in the message
+     * @param remove - Setting to true will remove this message with the next one
+     * @param animation - Array containing animation frames as elements
+     * @param printNow - Ignores the readyafterlogs check and force prints the message now
+     * @param cutToWidth - Cuts the string to the width of the terminal
+     */
+    logger(type: string, str: string, nodate: boolean, remove: boolean, animation: string[], printNow: boolean, cutToWidth: boolean): void;
+    /**
+     * Internal: Call this function after loading advancedconfig.json to set previously inaccessible options
+     * @param advancedconfig - The advancedconfig object imported by the DataManager
+     */
+    _loggerOptionsUpdateAfterConfigLoad(advancedconfig: any): void;
+    /**
+     * Internal: Logs all held back messages from logAfterReady array
+     */
+    _loggerLogAfterReady(): void;
+    /**
+     * Runs internal ready event code and emits ready event for plugins
+     */
+    _readyEvent(): void;
+    /**
+     * Runs internal statusUpdate event code and emits statusUpdate event for plugins
+     * @param bot - Bot instance
+     * @param newStatus - The new status of this bot
+     */
+    _statusUpdateEvent(bot: Bot, newStatus: Bot.EStatus): void;
+    /**
+     * Emits steamGuardInput event for bot & plugins
+     * @param bot - Bot instance of the affected account
+     * @param submitCode - Function to submit a code. Pass an empty string to skip the account.
+     */
+    _steamGuardInputEvent(bot: Bot, submitCode: (...params: any[]) => any): void;
+    /**
+     * Check if all friends are in lastcomment database
+     * @param bot - Bot object of the account to check
+     */
+    checkLastcommentDB(bot: Bot): void;
+    /**
+     * Checks the remaining space on the friendlist of a bot account, sends a warning message if it is less than 10 and force unfriends oldest lastcomment db user to always keep room for 1 friend.
+     * @param bot - Bot object of the account to check
+     */
+    friendListCapacityCheck(bot: Bot, callback: any): void;
+    /**
+     * Check for friends who haven't requested comments in config.unfriendtime days and unfriend them
+     */
+    _lastcommentUnfriendCheck(): void;
+    /**
+     * Retrieves all matching bot accounts and returns them.
+     * @param [statusFilter = EStatus.ONLINE] - Optional: EStatus or Array of EStatus's including account statuses to filter. Pass '*' to get all accounts. If omitted, only accs with status 'EStatus.ONLINE' will be returned.
+     * @param mapToObject - Optional: If true, an object will be returned where every bot object is mapped to their accountName.
+     * @returns An array or object if `mapToObject == true` containing all matching bot accounts.
+     */
+    getBots(statusFilter?: EStatus | EStatus[] | string, mapToObject: boolean): any[] | any;
+    /**
+     * Internal: Handles process's unhandledRejection & uncaughtException error events.
+     * Should a NPM related error be detected it attempts to reinstall all packages using our npminteraction helper function
+     */
+    _handleErrors(): void;
+    /**
+     * Handles converting URLs to steamIDs, determining their type if unknown and checking if it matches your expectation
+     * @param str - The profileID argument provided by the user
+     * @param expectedIdType - The type of SteamID expected ("profile", "group" or "sharedfile") or `null` if type should be assumed.
+     */
+    handleSteamIdResolving(str: string, expectedIdType: string, callback: any): void;
+    /**
+     * Logs text to the terminal and appends it to the output.txt file.
+     * @param type - String that determines the type of the log message. Can be info, warn, error, debug or an empty string to not use the field.
+     * @param str - The text to log into the terminal
+     * @param nodate - Setting to true will hide date and time in the message
+     * @param remove - Setting to true will remove this message with the next one
+     * @param animation - Array containing animation frames as elements
+     * @param printNow - Ignores the readyafterlogs check and force prints the message now
+     * @param cutToWidth - Cuts the string to the width of the terminal
+     */
+    logger(type: string, str: string, nodate: boolean, remove: boolean, animation: string[], printNow: boolean, cutToWidth: boolean): void;
+    /**
+     * Internal: Call this function after loading advancedconfig.json to set previously inaccessible options
+     * @param advancedconfig - The advancedconfig object imported by the DataManager
+     */
+    _loggerOptionsUpdateAfterConfigLoad(advancedconfig: any): void;
+    /**
+     * Internal: Logs all held back messages from logAfterReady array
+     */
+    _loggerLogAfterReady(): void;
+    /**
+     * Attempts to log in all bot accounts which are currently offline one after another.
+     * Creates a new bot object for every new account and reuses existing one if possible
+     * @param firstLogin - Is set to true by controller if this is the first login to display more information
+     */
+    login(firstLogin: boolean): void;
 }
 
 /**
  * Process data that should be kept over restarts
+ * @param data - Stringified data received by previous process
  */
-declare function restartdata(): void;
+declare function restartdata(data: string): void;
 
 /**
  * Implementation of a synchronous for loop in JS (Used as reference: https://whitfin.io/handling-synchronous-asynchronous-loops-javascriptnode-js/)
@@ -621,11 +574,7 @@ declare function restartdata(): void;
  * @param func - The function to run each iteration (Params: loop, index)
  * @param exit - This function will be called when the loop is finished
  */
-declare function syncLoop(
-  iterations: number,
-  func: (...params: any[]) => any,
-  exit: (...params: any[]) => any
-): void;
+declare function syncLoop(iterations: number, func: (...params: any[]) => any, exit: (...params: any[]) => any): void;
 
 /**
  * Rounds a number with x decimals
@@ -636,10 +585,11 @@ declare function syncLoop(
 declare function round(value: number, decimals: number): number;
 
 /**
- * Converts a timestamp to a human-readable until from now format. Does not care about past/future.
+ * Converts a timestamp to a human-readable "until from now" format. Does not care about past/future.
+ * @param timestamp - UNIX timestamp to convert
  * @returns "x seconds/minutes/hours/days"
  */
-declare function timeToString(): string;
+declare function timeToString(timestamp: number): string;
 
 /**
  * Pings an URL to check if the service and this internet connection is working
@@ -647,10 +597,7 @@ declare function timeToString(): string;
  * @param throwTimeout - If true, the function will throw a timeout error if Steam can't be reached after 20 seconds
  * @returns Resolves on response code 2xx and rejects on any other response code. Both are called with parameter `response` (Object) which has a `statusMessage` (String) and `statusCode` (Number) key. `statusCode` is `null` if request failed.
  */
-declare function checkConnection(
-  url: string,
-  throwTimeout: boolean
-): Promise<{ statusMessage: string; statusCode: number | null }>;
+declare function checkConnection(url: string, throwTimeout: boolean): Promise<{ statusMessage: string; statusCode: number | null; }>;
 
 /**
  * Helper function which attempts to cut Strings intelligently and returns all parts. It will attempt to not cut words & links in half.
@@ -661,325 +608,344 @@ declare function checkConnection(
  * @param threshold - Optional: Maximum amount that limit can be reduced to find the last space or line break. If no match is found within this limit a word will be cut. Default: 15% of total length
  * @returns Returns all parts of the string in an array
  */
-declare function cutStringsIntelligently(
-  txt: string,
-  limit: number,
-  cutChars: any[],
-  threshold: number
-): any[];
+declare function cutStringsIntelligently(txt: string, limit: number, cutChars: string[], threshold: number): any[];
 
 /**
  * Attempts to reinstall all modules
  * @param logger - The currently used logger function (real or fake, the caller decides)
- * @param [callback] - Called with `err` (String) and `stdout` (String) (npm response) parameters on completion
  */
-declare function reinstallAll(
-  logger: (...params: any[]) => any,
-  callback?: (...params: any[]) => any
-): void;
+declare function reinstallAll(logger: (...params: any[]) => any, callback: any): void;
 
 /**
  * Updates all installed packages to versions listed in package.json from the project root directory.
- * @param [callback] - Called with `err` (String) and `stdout` (String) (npm response) parameters on completion
  */
-declare function update(callback?: (...params: any[]) => any): void;
+declare function update(callback: any): void;
 
 /**
  * Updates all installed packages to versions listed in package.json
  * @param path - Custom path to read package.json from and install packages to
- * @param [callback] - Called with `err` (String) and `stdout` (String) (npm response) parameters on completion
  */
-declare function updateFromPath(
-  path: string,
-  callback?: (...params: any[]) => any
-): void;
+declare function updateFromPath(path: string, callback: any): void;
 
 /**
  * Constructor - The dataManager system imports, checks, handles errors and provides a file updating service for all configuration files
  * @param controller - Reference to the controller object
  */
 declare class DataManager {
-  constructor(controller: Controller);
-  /**
-   * Checks currently loaded data for validity and logs some recommendations for a few settings.
-   * @returns Resolves promise when all checks have finished. If promise is rejected you should terminate the application or reset the changes. Reject is called with a String specifying the failed check.
-   */
-  checkData(): Promise<void>;
-  /**
-   * Internal: Loads all config & data files from disk and handles potential errors
-   * @returns Resolves promise when all files have been loaded successfully. The function will log an error and terminate the application should a fatal error occur.
-   */
-  _importFromDisk(): Promise<void>;
-  /**
-   * Reference to the controller object
-   */
-  controller: Controller;
-  /**
-   * Stores all `data.json` values.
-   * Read only - Do NOT MODIFY anything in this file!
-   */
-  datafile: any;
-  /**
-   * Stores all `config.json` settings.
-   */
-  config: {
-    [key: string]: any;
-  };
-  /**
-   * Stores all `advancedconfig.json` settings.
-   */
-  advancedconfig: {
-    [key: string]: any;
-  };
-  /**
-   * Stores all language strings used for responding to a user.
-   * All default strings have already been replaced with corresponding matches from `customlang.json`.
-   */
-  lang: {
-    [key: string]: string;
-  };
-  /**
-   * Stores all quotes used for commenting provided via the `quotes.txt` file.
-   */
-  quotes: String[];
-  /**
-   * Stores all proxies provided via the `proxies.txt` file.
-   */
-  proxies: String[];
-  /**
-   * Stores IDs from config files converted at runtime and backups for all config & data files.
-   */
-  cachefile: any;
-  /**
-   * Stores the login information for every bot account provided via the `logininfo.json` or `accounts.txt` files.
-   */
-  logininfo: {
-    [key: string]: {
-      accountName: string;
-      password: string;
-      sharedSecret: string;
-      steamGuardCode: null;
-      machineName: string;
-      deviceFriendlyName: string;
-    };
-  };
-  /**
-   * Database which stores the timestamp of the last request of every user. This is used to enforce `config.unfriendTime`.
-   * Document structure: { id: String, time: Number }
-   */
-  lastCommentDB: Nedb;
-  /**
-   * Database which stores information about which bot accounts have already voted on which sharedfiles. This allows us to filter without pinging Steam for every account on every request.
-   * Document structure: { id: String, accountName: String, type: String, time: Number }
-   */
-  ratingHistoryDB: Nedb;
-  /**
-   * Database which stores the refreshTokens for all bot accounts.
-   * Document structure: { accountName: String, token: String }
-   */
-  tokensDB: Nedb;
-  /**
-   * Checks currently loaded data for validity and logs some recommendations for a few settings.
-   * @returns Resolves promise when all checks have finished. If promise is rejected you should terminate the application or reset the changes. Reject is called with a String specifying the failed check.
-   */
-  checkData(): Promise<void>;
-  /**
-   * Converts owners and groups imported from config.json to steam ids and updates cachefile. (Call this after dataImport and before dataCheck)
-   */
-  processData(): void;
-  /**
-   * Internal: Loads all config & data files from disk and handles potential errors
-   * @returns Resolves promise when all files have been loaded successfully. The function will log an error and terminate the application should a fatal error occur.
-   */
-  _importFromDisk(): Promise<void>;
-  /**
-   * Gets a random quote
-   * @param quotesArr - Optional: Custom array of quotes to choose from. If not provided the default quotes set which was imported from the disk will be used.
-   * @returns Resolves with `quote` (String)
-   */
-  getQuote(quotesArr: any[]): Promise<string>;
-  /**
-   * Checks if a user ID is currently on cooldown and formats human readable lastRequestStr and untilStr strings.
-   * @param id - ID of the user to look up
-   * @returns Resolves with object containing `lastRequest` (Unix timestamp of the last interaction received), `until` (Unix timestamp of cooldown end), `lastRequestStr` (How long ago as String), `untilStr` (Wait until as String). If id wasn't found, `null` will be returned.
-   */
-  getUserCooldown(id: string): Promise<{
-    lastRequest: number;
-    until: number;
-    lastRequestStr: string;
-    untilStr: string;
-  } | null>;
-  /**
-   * Updates or inserts timestamp of a user
-   * @param id - ID of the user to update
-   * @param timestamp - Unix timestamp of the last interaction the user received
-   */
-  setUserCooldown(id: string, timestamp: number): void;
-  /**
-   * Internal: Checks tokens.db every 24 hours for refreshToken expiration in <=7 days, logs warning and sends botowner a Steam msg
-   */
-  _startExpiringTokensCheckInterval(): void;
-  /**
-   * Internal: Asks user if he/she wants to refresh the tokens of all expiring accounts when no active request was found and relogs them
-   * @param expiring - Object of botobject entries to ask user for
-   */
-  _askForGetNewToken(expiring: any): void;
-  /**
-   * Retrieves the last processed request of anyone or a specific steamID64 from the lastcomment database
-   * @param steamID64 - Search for a specific user
-   * @returns Called with the greatest timestamp (Number) found
-   */
-  getLastCommentRequest(steamID64: string): Promise<number>;
-  /**
-   * Decodes a JsonWebToken - https://stackoverflow.com/a/38552302
-   * @param token - The token to decode
-   * @returns JWT object on success, `null` on failure
-   */
-  decodeJWT(token: string): any;
-  /**
-   * Refreshes Backups in cache.json with new data
-   */
-  refreshCache(): void;
-  /**
-   * Internal: Helper function to try and restore backup of corrupted file from cache.json
-   * @param name - Name of the file
-   * @param filepath - Absolute path of the file on the disk
-   * @param cacheentry - Backup-Object of the file in cache.json
-   * @param onlinelink - Link to the raw file in the GitHub repository
-   * @param resolve - Function to resolve the caller's promise
-   */
-  _restoreBackup(
-    name: string,
-    filepath: string,
-    cacheentry: any,
-    onlinelink: string,
-    resolve: (...params: any[]) => any
-  ): void;
-  /**
-   * Internal: Helper function to pull new file from GitHub
-   */
-  _pullNewFile(): void;
-  /**
-   * Converts owners and groups imported from config.json to steam ids and updates cachefile. (Call this after dataImport and before dataCheck)
-   */
-  processData(): void;
-  /**
-   * Gets a random quote
-   * @param quotesArr - Optional: Custom array of quotes to choose from. If not provided the default quotes set which was imported from the disk will be used.
-   * @returns Resolves with `quote` (String)
-   */
-  getQuote(quotesArr: any[]): Promise<string>;
-  /**
-   * Checks if a user ID is currently on cooldown and formats human readable lastRequestStr and untilStr strings.
-   * @param id - ID of the user to look up
-   * @returns Resolves with object containing `lastRequest` (Unix timestamp of the last interaction received), `until` (Unix timestamp of cooldown end), `lastRequestStr` (How long ago as String), `untilStr` (Wait until as String). If id wasn't found, `null` will be returned.
-   */
-  getUserCooldown(id: string): Promise<{
-    lastRequest: number;
-    until: number;
-    lastRequestStr: string;
-    untilStr: string;
-  } | null>;
-  /**
-   * Updates or inserts timestamp of a user
-   * @param id - ID of the user to update
-   * @param timestamp - Unix timestamp of the last interaction the user received
-   */
-  setUserCooldown(id: string, timestamp: number): void;
-  /**
-   * Internal: Checks tokens.db every 24 hours for refreshToken expiration in <=7 days, logs warning and sends botowner a Steam msg
-   */
-  _startExpiringTokensCheckInterval(): void;
-  /**
-   * Internal: Asks user if he/she wants to refresh the tokens of all expiring accounts when no active request was found and relogs them
-   * @param expiring - Object of botobject entries to ask user for
-   */
-  _askForGetNewToken(expiring: any): void;
-  /**
-   * Retrieves the last processed request of anyone or a specific steamID64 from the lastcomment database
-   * @param steamID64 - Search for a specific user
-   * @returns Called with the greatest timestamp (Number) found
-   */
-  getLastCommentRequest(steamID64: string): Promise<number>;
-  /**
-   * Decodes a JsonWebToken - https://stackoverflow.com/a/38552302
-   * @param token - The token to decode
-   * @returns JWT object on success, `null` on failure
-   */
-  decodeJWT(token: string): any;
-  /**
-   * Refreshes Backups in cache.json with new data
-   */
-  refreshCache(): void;
-  /**
-   * Internal: Helper function to try and restore backup of corrupted file from cache.json
-   * @param name - Name of the file
-   * @param filepath - Absolute path of the file on the disk
-   * @param cacheentry - Backup-Object of the file in cache.json
-   * @param onlinelink - Link to the raw file in the GitHub repository
-   * @param resolve - Function to resolve the caller's promise
-   */
-  _restoreBackup(
-    name: string,
-    filepath: string,
-    cacheentry: any,
-    onlinelink: string,
-    resolve: (...params: any[]) => any
-  ): void;
-  /**
-   * Internal: Helper function to pull new file from GitHub
-   */
-  _pullNewFile(): void;
+    constructor(controller: Controller);
+    /**
+     * Checks currently loaded data for validity and logs some recommendations for a few settings.
+     * @returns Resolves promise when all checks have finished. If promise is rejected you should terminate the application or reset the changes. Reject is called with a String specifying the failed check.
+     */
+    checkData(): Promise<void>;
+    /**
+     * Writes (all) files imported by DataManager back to the disk
+     */
+    writeAllFilesToDisk(): void;
+    /**
+     * Writes cachefile to cache.json on disk
+     */
+    writeCachefileToDisk(): void;
+    /**
+     * Writes datafile to data.json on disk
+     */
+    writeDatafileToDisk(): void;
+    /**
+     * Writes config to config.json on disk
+     */
+    writeConfigToDisk(): void;
+    /**
+     * Writes advancedconfig to advancedconfig.json on disk
+     */
+    writeAdvancedconfigToDisk(): void;
+    /**
+     * Writes logininfo to logininfo.json and accounts.txt on disk, depending on which of the files exist
+     */
+    writeLogininfoToDisk(): void;
+    /**
+     * Writes proxies to proxies.txt on disk
+     */
+    writeProxiesToDisk(): void;
+    /**
+     * Writes quotes to quotes.txt on disk
+     */
+    writeQuotesToDisk(): void;
+    /**
+     * Internal: Loads all config & data files from disk and handles potential errors
+     * @returns Resolves promise when all files have been loaded successfully. The function will log an error and terminate the application should a fatal error occur.
+     */
+    _importFromDisk(): Promise<void>;
+    /**
+     * Reference to the controller object
+     */
+    controller: Controller;
+    /**
+     * Stores all `data.json` values.
+     * Read only - Do NOT MODIFY anything in this file!
+     */
+    datafile: any;
+    /**
+     * Stores all `config.json` settings.
+     */
+    config: any;
+    /**
+     * Stores all `advancedconfig.json` settings.
+     */
+    advancedconfig: any;
+    /**
+     * Stores all language strings used for responding to a user.
+     * All default strings have already been replaced with corresponding matches from `customlang.json`.
+     */
+    lang: any;
+    /**
+     * Stores all quotes used for commenting provided via the `quotes.txt` file.
+     */
+    quotes: string[];
+    /**
+     * Stores all proxies provided via the `proxies.txt` file.
+     */
+    proxies: string[];
+    /**
+     * Stores IDs from config files converted at runtime and backups for all config & data files.
+     */
+    cachefile: any;
+    /**
+     * Stores the login information for every bot account provided via the `logininfo.json` or `accounts.txt` files.
+     */
+    logininfo: any;
+    /**
+     * Database which stores the timestamp of the last request of every user. This is used to enforce `config.unfriendTime`.
+     * Document structure: { id: String, time: Number }
+     */
+    lastCommentDB: Nedb;
+    /**
+     * Database which stores information about which bot accounts have already voted on which sharedfiles. This allows us to filter without pinging Steam for every account on every request.
+     * Document structure: { id: String, accountName: String, type: String, time: Number }
+     */
+    ratingHistoryDB: Nedb;
+    /**
+     * Database which stores the refreshTokens for all bot accounts.
+     * Document structure: { accountName: String, token: String }
+     */
+    tokensDB: Nedb;
+    /**
+     * Checks currently loaded data for validity and logs some recommendations for a few settings.
+     * @returns Resolves promise when all checks have finished. If promise is rejected you should terminate the application or reset the changes. Reject is called with a String specifying the failed check.
+     */
+    checkData(): Promise<void>;
+    /**
+     * Writes (all) files imported by DataManager back to the disk
+     */
+    writeAllFilesToDisk(): void;
+    /**
+     * Writes cachefile to cache.json on disk
+     */
+    writeCachefileToDisk(): void;
+    /**
+     * Writes datafile to data.json on disk
+     */
+    writeDatafileToDisk(): void;
+    /**
+     * Writes config to config.json on disk
+     */
+    writeConfigToDisk(): void;
+    /**
+     * Writes advancedconfig to advancedconfig.json on disk
+     */
+    writeAdvancedconfigToDisk(): void;
+    /**
+     * Writes logininfo to logininfo.json and accounts.txt on disk, depending on which of the files exist
+     */
+    writeLogininfoToDisk(): void;
+    /**
+     * Writes proxies to proxies.txt on disk
+     */
+    writeProxiesToDisk(): void;
+    /**
+     * Writes quotes to quotes.txt on disk
+     */
+    writeQuotesToDisk(): void;
+    /**
+     * Internal: Loads all config & data files from disk and handles potential errors
+     * @returns Resolves promise when all files have been loaded successfully. The function will log an error and terminate the application should a fatal error occur.
+     */
+    _importFromDisk(): Promise<void>;
+    /**
+     * Converts owners and groups imported from config.json to steam ids and updates cachefile. (Call this after dataImport and before dataCheck)
+     */
+    processData(): void;
+    /**
+     * Gets a random quote
+     * @param quotesArr - Optional: Custom array of quotes to choose from. If not provided the default quotes set which was imported from the disk will be used.
+     * @returns Resolves with `quote` (String)
+     */
+    getQuote(quotesArr: any[]): Promise<string>;
+    /**
+     * Checks if a user ID is currently on cooldown and formats human readable lastRequestStr and untilStr strings.
+     * @param id - ID of the user to look up
+     * @returns Resolves with object containing `lastRequest` (Unix timestamp of the last interaction received), `until` (Unix timestamp of cooldown end), `lastRequestStr` (How long ago as String), `untilStr` (Wait until as String). If id wasn't found, `null` will be returned.
+     */
+    getUserCooldown(id: string): Promise<{ lastRequest: number; until: number; lastRequestStr: string; untilStr: string; } | null>;
+    /**
+     * Updates or inserts timestamp of a user
+     * @param id - ID of the user to update
+     * @param timestamp - Unix timestamp of the last interaction the user received
+     */
+    setUserCooldown(id: string, timestamp: number): void;
+    /**
+     * Internal: Checks tokens.db every 24 hours for refreshToken expiration in <=7 days, logs warning and sends botowner a Steam msg
+     */
+    _startExpiringTokensCheckInterval(): void;
+    /**
+     * Internal: Asks user if he/she wants to refresh the tokens of all expiring accounts when no active request was found and relogs them
+     * @param expiring - Object of botobject entries to ask user for
+     */
+    _askForGetNewToken(expiring: any): void;
+    /**
+     * Retrieves the last processed request of anyone or a specific steamID64 from the lastcomment database
+     * @param steamID64 - Search for a specific user
+     * @returns Called with the greatest timestamp (Number) found
+     */
+    getLastCommentRequest(steamID64: string): Promise<number>;
+    /**
+     * Decodes a JsonWebToken - https://stackoverflow.com/a/38552302
+     * @param token - The token to decode
+     * @returns JWT object on success, `null` on failure
+     */
+    decodeJWT(token: string): any | null;
+    /**
+     * Refreshes Backups in cache.json with new data
+     */
+    refreshCache(): void;
+    /**
+     * Internal: Helper function to try and restore backup of corrupted file from cache.json
+     * @param name - Name of the file
+     * @param filepath - Absolute path of the file on the disk
+     * @param cacheentry - Backup-Object of the file in cache.json
+     * @param onlinelink - Link to the raw file in the GitHub repository
+     * @param resolve - Function to resolve the caller's promise
+     */
+    _restoreBackup(name: string, filepath: string, cacheentry: any, onlinelink: string, resolve: (...params: any[]) => any): void;
+    /**
+     * Internal: Helper function to pull new file from GitHub
+     * @param name - Name of the file
+     * @param filepath - Full path, starting from project root with './'
+     * @param resolve - Your promise to resolve when file was pulled
+     * @param noRequire - Optional: Set to true if resolve() should not be called with require(file) as param
+     */
+    _pullNewFile(name: string, filepath: string, resolve: (...params: any[]) => any, noRequire: boolean): void;
+    /**
+     * Converts owners and groups imported from config.json to steam ids and updates cachefile. (Call this after dataImport and before dataCheck)
+     */
+    processData(): void;
+    /**
+     * Gets a random quote
+     * @param quotesArr - Optional: Custom array of quotes to choose from. If not provided the default quotes set which was imported from the disk will be used.
+     * @returns Resolves with `quote` (String)
+     */
+    getQuote(quotesArr: any[]): Promise<string>;
+    /**
+     * Checks if a user ID is currently on cooldown and formats human readable lastRequestStr and untilStr strings.
+     * @param id - ID of the user to look up
+     * @returns Resolves with object containing `lastRequest` (Unix timestamp of the last interaction received), `until` (Unix timestamp of cooldown end), `lastRequestStr` (How long ago as String), `untilStr` (Wait until as String). If id wasn't found, `null` will be returned.
+     */
+    getUserCooldown(id: string): Promise<{ lastRequest: number; until: number; lastRequestStr: string; untilStr: string; } | null>;
+    /**
+     * Updates or inserts timestamp of a user
+     * @param id - ID of the user to update
+     * @param timestamp - Unix timestamp of the last interaction the user received
+     */
+    setUserCooldown(id: string, timestamp: number): void;
+    /**
+     * Internal: Checks tokens.db every 24 hours for refreshToken expiration in <=7 days, logs warning and sends botowner a Steam msg
+     */
+    _startExpiringTokensCheckInterval(): void;
+    /**
+     * Internal: Asks user if he/she wants to refresh the tokens of all expiring accounts when no active request was found and relogs them
+     * @param expiring - Object of botobject entries to ask user for
+     */
+    _askForGetNewToken(expiring: any): void;
+    /**
+     * Retrieves the last processed request of anyone or a specific steamID64 from the lastcomment database
+     * @param steamID64 - Search for a specific user
+     * @returns Called with the greatest timestamp (Number) found
+     */
+    getLastCommentRequest(steamID64: string): Promise<number>;
+    /**
+     * Decodes a JsonWebToken - https://stackoverflow.com/a/38552302
+     * @param token - The token to decode
+     * @returns JWT object on success, `null` on failure
+     */
+    decodeJWT(token: string): any | null;
+    /**
+     * Refreshes Backups in cache.json with new data
+     */
+    refreshCache(): void;
+    /**
+     * Internal: Helper function to try and restore backup of corrupted file from cache.json
+     * @param name - Name of the file
+     * @param filepath - Absolute path of the file on the disk
+     * @param cacheentry - Backup-Object of the file in cache.json
+     * @param onlinelink - Link to the raw file in the GitHub repository
+     * @param resolve - Function to resolve the caller's promise
+     */
+    _restoreBackup(name: string, filepath: string, cacheentry: any, onlinelink: string, resolve: (...params: any[]) => any): void;
+    /**
+     * Internal: Helper function to pull new file from GitHub
+     * @param name - Name of the file
+     * @param filepath - Full path, starting from project root with './'
+     * @param resolve - Your promise to resolve when file was pulled
+     * @param noRequire - Optional: Set to true if resolve() should not be called with require(file) as param
+     */
+    _pullNewFile(name: string, filepath: string, resolve: (...params: any[]) => any, noRequire: boolean): void;
 }
 
 /**
- * Constructor - Creates a new Sharedfile object
+ * Constructor - Creates a new SharedFile object
  */
-declare class CSteamSharedfile {
-  constructor(community: SteamCommunity, data: any);
-  /**
-   * Deletes a comment from this sharedfile's comment section
-   * @param cid - ID of the comment to delete
-   * @param callback - Takes only an Error object/null as the first argument
-   */
-  deleteComment(cid: string, callback: (...params: any[]) => any): void;
-  /**
-   * Favorites this sharedfile
-   * @param callback - Takes only an Error object/null as the first argument
-   */
-  favorite(callback: (...params: any[]) => any): void;
-  /**
-   * Posts a comment to this sharedfile
-   * @param message - Content of the comment to post
-   * @param callback - Takes only an Error object/null as the first argument
-   */
-  comment(message: string, callback: (...params: any[]) => any): void;
-  /**
-   * Subscribes to this sharedfile's comment section. Note: Checkbox on webpage does not update
-   * @param callback - Takes only an Error object/null as the first argument
-   */
-  subscribe(callback: (...params: any[]) => any): void;
-  /**
-   * Unfavorites this sharedfile
-   * @param callback - Takes only an Error object/null as the first argument
-   */
-  unfavorite(callback: (...params: any[]) => any): void;
-  /**
-   * Unsubscribes from this sharedfile's comment section. Note: Checkbox on webpage does not update
-   * @param callback - Takes only an Error object/null as the first argument
-   */
-  unsubscribe(callback: (...params: any[]) => any): void;
-  /**
-   * Downvotes this sharedfile
-   * @param callback - Takes only an Error object/null as the first argument
-   */
-  voteDown(callback: (...params: any[]) => any): void;
-  /**
-   * Upvotes this sharedfile
-   * @param callback - Takes only an Error object/null as the first argument
-   */
-  voteUp(callback: (...params: any[]) => any): void;
+declare class CSteamSharedFile {
+    constructor(community: SteamCommunity, data: any);
+    _community: SteamCommunity;
+    /**
+     * Deletes a comment from this sharedfile's comment section
+     * @param cid - ID of the comment to delete
+     * @param callback - Takes only an Error object/null as the first argument
+     */
+    deleteComment(cid: string, callback: (...params: any[]) => any): void;
+    /**
+     * Favorites this sharedfile
+     * @param callback - Takes only an Error object/null as the first argument
+     */
+    favorite(callback: (...params: any[]) => any): void;
+    /**
+     * Posts a comment to this sharedfile
+     * @param message - Content of the comment to post
+     * @param callback - Takes only an Error object/null as the first argument
+     */
+    comment(message: string, callback: (...params: any[]) => any): void;
+    /**
+     * Subscribes to this sharedfile's comment section. Note: Checkbox on webpage does not update
+     * @param callback - Takes only an Error object/null as the first argument
+     */
+    subscribe(callback: (...params: any[]) => any): void;
+    /**
+     * Unfavorites this sharedfile
+     * @param callback - Takes only an Error object/null as the first argument
+     */
+    unfavorite(callback: (...params: any[]) => any): void;
+    /**
+     * Unsubscribes from this sharedfile's comment section. Note: Checkbox on webpage does not update
+     * @param callback - Takes only an Error object/null as the first argument
+     */
+    unsubscribe(callback: (...params: any[]) => any): void;
 }
+
+/**
+ * Attempt to load all plugins. If a critical check fails loading will be denied
+ * @param pluginName - Name of the plugin package
+ * @returns Creates a plugin instance and returns it along with more information
+ */
+declare function loadPlugin(pluginName: string): any;
 
 /**
  * @property load - Called on Plugin load
@@ -989,11 +955,11 @@ declare class CSteamSharedfile {
  * @property steamGuardInput - Controller steamGuardInput event
  */
 declare type Plugin = {
-  load: (...params: any[]) => any;
-  unload: (...params: any[]) => any;
-  ready: (...params: any[]) => any;
-  statusUpdate: (...params: any[]) => any;
-  steamGuardInput: (...params: any[]) => any;
+    load: (...params: any[]) => any;
+    unload: (...params: any[]) => any;
+    ready: (...params: any[]) => any;
+    statusUpdate: (...params: any[]) => any;
+    steamGuardInput: (...params: any[]) => any;
 };
 
 /**
@@ -1001,118 +967,128 @@ declare type Plugin = {
  * @param controller - Reference to the controller object
  */
 declare class PluginSystem {
-  constructor(controller: Controller);
-  /**
-   * Gets the path holding all data of a plugin. If no folder exists yet, one will be created
-   * @param pluginName - Name of your plugin
-   * @returns Path to the folder containing your plugin data
-   */
-  getPluginDataPath(pluginName: string): string;
-  /**
-   * Loads a file from your plugin data folder. The data will remain unprocessed. Use `loadPluginConfig()` instead if you want to load your plugin config.
-   * @param pluginName - Name of your plugin
-   * @param filename - Name of the file to load
-   * @returns Resolves with data on success, rejects otherwise with an error
-   */
-  loadPluginData(pluginName: string, filename: string): Promise<any>;
-  /**
-   * Writes a file to your plugin data folder. The data will remain unprocessed. Use `writePluginConfig()` instead if you want to write your plugin config.
-   * @param pluginName - Name of your plugin
-   * @param filename - Name of the file to load
-   * @param data - The data to write
-   * @returns Resolves on success, rejects otherwise with an error
-   */
-  writePluginData(
-    pluginName: string,
-    filename: string,
-    data: string
-  ): Promise<void>;
-  /**
-   * Loads your plugin config from the filesystem or creates a new one based on the default config provided by your plugin. The JSON data will be processed to an object.
-   * @param pluginName - Name of your plugin
-   * @returns Resolves with your plugin config processed from JSON to an object. If the config failed to load, the promise will be rejected with an error.
-   */
-  loadPluginConfig(pluginName: string): Promise<object>;
-  /**
-   * Writes your plugin config changes to the filesystem. The object data will be processed to JSON.
-   * @param pluginName - Name of your plugin
-   * @param pluginConfig - Config object of your plugin
-   * @returns Resolves on success, rejects otherwise with an error
-   */
-  writePluginConfig(pluginName: string, pluginConfig: any): Promise<void>;
-  /**
-   * Internal: Loads all plugin npm packages and populates pluginList
-   */
-  _loadPlugins(): void;
-  /**
-   * Reference to the controller object
-   */
-  controller: Controller;
-  /**
-   * References to all plugin objects
-   */
-  pluginList: {
-    [key: string]: Plugin;
-  };
-  commandHandler: CommandHandler;
-  /**
-   * Reloads all plugins and calls ready event after ~2.5 seconds.
-   */
-  reloadPlugins(): void;
-  /**
-   * Internal: Loads all plugin npm packages and populates pluginList
-   */
-  _loadPlugins(): void;
-  /**
-   * Internal: Checks a plugin, displays relevant warnings and decides whether the plugin is allowed to be loaded
-   * @param folderName - Name of the plugin folder. This is used to reference the plugin when thisPluginConf is undefined
-   * @param thisPlugin - Plugin file object returned by require()
-   * @param thisPluginConf - package.json object of this plugin
-   * @returns Resolved with `true` (can be loaded) or `false` (must not be loaded) on completion
-   */
-  _checkPlugin(
-    folderName: string,
-    thisPlugin: any,
-    thisPluginConf: any
-  ): Promise<boolean>;
-  /**
-   * Gets the path holding all data of a plugin. If no folder exists yet, one will be created
-   * @param pluginName - Name of your plugin
-   * @returns Path to the folder containing your plugin data
-   */
-  getPluginDataPath(pluginName: string): string;
-  /**
-   * Loads a file from your plugin data folder. The data will remain unprocessed. Use `loadPluginConfig()` instead if you want to load your plugin config.
-   * @param pluginName - Name of your plugin
-   * @param filename - Name of the file to load
-   * @returns Resolves with data on success, rejects otherwise with an error
-   */
-  loadPluginData(pluginName: string, filename: string): Promise<any>;
-  /**
-   * Writes a file to your plugin data folder. The data will remain unprocessed. Use `writePluginConfig()` instead if you want to write your plugin config.
-   * @param pluginName - Name of your plugin
-   * @param filename - Name of the file to load
-   * @param data - The data to write
-   * @returns Resolves on success, rejects otherwise with an error
-   */
-  writePluginData(
-    pluginName: string,
-    filename: string,
-    data: string
-  ): Promise<void>;
-  /**
-   * Loads your plugin config from the filesystem or creates a new one based on the default config provided by your plugin. The JSON data will be processed to an object.
-   * @param pluginName - Name of your plugin
-   * @returns Resolves with your plugin config processed from JSON to an object. If the config failed to load, the promise will be rejected with an error.
-   */
-  loadPluginConfig(pluginName: string): Promise<object>;
-  /**
-   * Writes your plugin config changes to the filesystem. The object data will be processed to JSON.
-   * @param pluginName - Name of your plugin
-   * @param pluginConfig - Config object of your plugin
-   * @returns Resolves on success, rejects otherwise with an error
-   */
-  writePluginConfig(pluginName: string, pluginConfig: any): Promise<void>;
+    constructor(controller: Controller);
+    /**
+     * Gets the path holding all data of a plugin. If no folder exists yet, one will be created
+     * @param pluginName - Name of your plugin
+     * @returns Path to the folder containing your plugin data
+     */
+    getPluginDataPath(pluginName: string): string;
+    /**
+     * Loads a file from your plugin data folder. The data will remain unprocessed. Use `loadPluginConfig()` instead if you want to load your plugin config.
+     * @param pluginName - Name of your plugin
+     * @param filename - Name of the file to load
+     * @returns Resolves with data on success, rejects otherwise with an error
+     */
+    loadPluginData(pluginName: string, filename: string): Promise<any>;
+    /**
+     * Writes a file to your plugin data folder. The data will remain unprocessed. Use `writePluginConfig()` instead if you want to write your plugin config.
+     * @param pluginName - Name of your plugin
+     * @param filename - Name of the file to load
+     * @param data - The data to write
+     * @returns Resolves on success, rejects otherwise with an error
+     */
+    writePluginData(pluginName: string, filename: string, data: string): Promise<void>;
+    /**
+     * Deletes a file in your plugin data folder if it exists.
+     * @param pluginName - Name of your plugin
+     * @param filename - Name of the file to load
+     * @returns Resolves on success, rejects otherwise with an error
+     */
+    deletePluginData(pluginName: string, filename: string): Promise<void>;
+    /**
+     * Loads your plugin config from the filesystem or creates a new one based on the default config provided by your plugin. The JSON data will be processed to an object.
+     * @param pluginName - Name of your plugin
+     * @returns Resolves with your plugin config processed from JSON to an object. If the config failed to load, the promise will be rejected with an error.
+     */
+    loadPluginConfig(pluginName: string): Promise<object>;
+    /**
+     * Integrates changes made to the config to the users config
+     * @returns the config
+     */
+    aggregatePluginConfig(pluginName: string): Record<string, any>;
+    /**
+     * Writes your plugin config changes to the filesystem. The object data will be processed to JSON.
+     * @param pluginName - Name of your plugin
+     * @param pluginConfig - Config object of your plugin
+     * @returns Resolves on success, rejects otherwise with an error
+     */
+    writePluginConfig(pluginName: string, pluginConfig: any): Promise<void>;
+    /**
+     * Internal: Loads all plugin npm packages and populates pluginList
+     */
+    _loadPlugins(): void;
+    /**
+     * Reference to the controller object
+     */
+    controller: Controller;
+    /**
+     * References to all plugin objects
+     */
+    pluginList: any;
+    commandHandler: CommandHandler;
+    /**
+     * Reloads all plugins and calls ready event after ~2.5 seconds.
+     */
+    reloadPlugins(): void;
+    /**
+     * Internal: Loads all plugin npm packages and populates pluginList
+     */
+    _loadPlugins(): void;
+    /**
+     * Internal: Checks a plugin, displays relevant warnings and decides whether the plugin is allowed to be loaded
+     * @param folderName - Name of the plugin folder. This is used to reference the plugin when thisPluginConf is undefined
+     * @param thisPlugin - Plugin file object returned by require()
+     * @param thisPluginConf - package.json object of this plugin
+     * @returns Resolved with `true` (can be loaded) or `false` (must not be loaded) on completion
+     */
+    _checkPlugin(folderName: string, thisPlugin: any, thisPluginConf: any): Promise<boolean>;
+    /**
+     * Gets the path holding all data of a plugin. If no folder exists yet, one will be created
+     * @param pluginName - Name of your plugin
+     * @returns Path to the folder containing your plugin data
+     */
+    getPluginDataPath(pluginName: string): string;
+    /**
+     * Loads a file from your plugin data folder. The data will remain unprocessed. Use `loadPluginConfig()` instead if you want to load your plugin config.
+     * @param pluginName - Name of your plugin
+     * @param filename - Name of the file to load
+     * @returns Resolves with data on success, rejects otherwise with an error
+     */
+    loadPluginData(pluginName: string, filename: string): Promise<any>;
+    /**
+     * Writes a file to your plugin data folder. The data will remain unprocessed. Use `writePluginConfig()` instead if you want to write your plugin config.
+     * @param pluginName - Name of your plugin
+     * @param filename - Name of the file to load
+     * @param data - The data to write
+     * @returns Resolves on success, rejects otherwise with an error
+     */
+    writePluginData(pluginName: string, filename: string, data: string): Promise<void>;
+    /**
+     * Deletes a file in your plugin data folder if it exists.
+     * @param pluginName - Name of your plugin
+     * @param filename - Name of the file to load
+     * @returns Resolves on success, rejects otherwise with an error
+     */
+    deletePluginData(pluginName: string, filename: string): Promise<void>;
+    /**
+     * Loads your plugin config from the filesystem or creates a new one based on the default config provided by your plugin. The JSON data will be processed to an object.
+     * @param pluginName - Name of your plugin
+     * @returns Resolves with your plugin config processed from JSON to an object. If the config failed to load, the promise will be rejected with an error.
+     */
+    loadPluginConfig(pluginName: string): Promise<object>;
+    /**
+     * Writes your plugin config changes to the filesystem. The object data will be processed to JSON.
+     * @param pluginName - Name of your plugin
+     * @param pluginConfig - Config object of your plugin
+     * @returns Resolves on success, rejects otherwise with an error
+     */
+    writePluginConfig(pluginName: string, pluginConfig: any): Promise<void>;
+    /**
+     * Integrates changes made to the config to the users config
+     * @returns the config
+     */
+    aggregatePluginConfig(pluginName: string): Record<string, any>;
 }
 
 /**
@@ -1120,96 +1096,110 @@ declare class PluginSystem {
  * @param bot - The bot object of this account
  */
 declare class SessionHandler {
-  constructor(bot: Bot);
-  /**
-   * Internal: Attaches listeners to all steam-session events we care about
-   */
-  _attachEvents(): void;
-  /**
-   * Internal: Handles submitting 2FA code
-   * @param res - Response object from startWithCredentials() promise
-   */
-  _handle2FA(res: any): void;
-  /**
-   * Internal: Helper function to get 2FA code from user and passing it to accept function or skipping account if desired
-   */
-  _get2FAUserInput(): void;
-  /**
-   * Internal: Helper function to make accepting and re-requesting invalid steam guard codes easier
-   * @param code - Input from user
-   */
-  _acceptSteamGuardCode(code: string): void;
-  /**
-   * Helper function to make handling login errors easier
-   * @param err - Error thrown by startWithCredentials()
-   */
-  _handleCredentialsLoginError(err: any): void;
-  /**
-   * Internal - Attempts to get a token for this account from tokens.db and checks if it's valid
-   * @param [callback] - Called with `refreshToken` (String) on success or `null` on failure
-   */
-  _getTokenFromStorage(callback?: (...params: any[]) => any): void;
-  /**
-   * Internal - Saves a new token for this account to tokens.db
-   * @param token - The refreshToken to store
-   */
-  _saveTokenToStorage(token: string): void;
-  /**
-   * Remove the token of this account from tokens.db. Intended to be called from the steam-user login error event when an invalid token was used so the next login attempt will create a new one.
-   */
-  invalidateTokenInStorage(): void;
-  /**
-   * Handles getting a refresh token for steam-user to auth with
-   * @returns `refreshToken` on success or `null` on failure
-   */
-  getToken(): Promise<string | null>;
-  /**
-   * Internal - Handles resolving the getToken() promise and skipping the account if necessary
-   * @param token - The token to resolve with or null when account should be skipped
-   */
-  _resolvePromise(token: string): void;
-  /**
-   * Internal - Attempts to log into account with credentials
-   */
-  _attemptCredentialsLogin(): void;
-  /**
-   * Internal: Attaches listeners to all steam-session events we care about
-   */
-  _attachEvents(): void;
-  /**
-   * Internal: Handles submitting 2FA code
-   * @param res - Response object from startWithCredentials() promise
-   */
-  _handle2FA(res: any): void;
-  /**
-   * Internal: Helper function to get 2FA code from user and passing it to accept function or skipping account if desired
-   */
-  _get2FAUserInput(): void;
-  /**
-   * Internal: Helper function to make accepting and re-requesting invalid steam guard codes easier
-   * @param code - Input from user
-   */
-  _acceptSteamGuardCode(code: string): void;
-  /**
-   * Helper function to make handling login errors easier
-   * @param err - Error thrown by startWithCredentials()
-   */
-  _handleCredentialsLoginError(err: any): void;
-  /**
-   * Internal - Attempts to get a token for this account from tokens.db and checks if it's valid
-   * @param [callback] - Called with `refreshToken` (String) on success or `null` on failure
-   */
-  _getTokenFromStorage(callback?: (...params: any[]) => any): void;
-  /**
-   * Internal - Saves a new token for this account to tokens.db
-   * @param token - The refreshToken to store
-   */
-  _saveTokenToStorage(token: string): void;
-  /**
-   * Remove the token of this account from tokens.db. Intended to be called from the steam-user login error event when an invalid token was used so the next login attempt will create a new one.
-   */
-  invalidateTokenInStorage(): void;
+    constructor(bot: Bot);
+    /**
+     * Internal: Attaches listeners to all steam-session events we care about
+     */
+    _attachEvents(): void;
+    /**
+     * Internal: Handles submitting 2FA code
+     * @param res - Response object from startWithCredentials() promise
+     */
+    _handle2FA(res: any): void;
+    /**
+     * Internal: Helper function to get 2FA code from user and passing it to accept function or skipping account if desired
+     */
+    _get2FAUserInput(): void;
+    /**
+     * Internal: Helper function to make accepting and re-requesting invalid steam guard codes easier
+     * @param code - Input from user
+     */
+    _acceptSteamGuardCode(code: string): void;
+    /**
+     * Helper function to make handling login errors easier
+     * @param err - Error thrown by startWithCredentials()
+     */
+    _handleCredentialsLoginError(err: any): void;
+    /**
+     * Internal - Attempts to get a token for this account from tokens.db and checks if it's valid
+     */
+    _getTokenFromStorage(callback: any): void;
+    /**
+     * Internal - Saves a new token for this account to tokens.db
+     * @param token - The refreshToken to store
+     */
+    _saveTokenToStorage(token: string): void;
+    /**
+     * Remove the token of this account from tokens.db. Intended to be called from the steam-user login error event when an invalid token was used so the next login attempt will create a new one.
+     */
+    invalidateTokenInStorage(): void;
+    /**
+     * Handles getting a refresh token for steam-user to auth with
+     * @returns `refreshToken` on success or `null` on failure
+     */
+    getToken(): Promise<string | null>;
+    /**
+     * Internal - Handles resolving the getToken() promise and skipping the account if necessary
+     * @param token - The token to resolve with or null when account should be skipped
+     */
+    _resolvePromise(token: string): void;
+    /**
+     * Internal - Attempts to log into account with credentials
+     */
+    _attemptCredentialsLogin(): void;
+    /**
+     * Internal: Attaches listeners to all steam-session events we care about
+     */
+    _attachEvents(): void;
+    /**
+     * Internal: Handles submitting 2FA code
+     * @param res - Response object from startWithCredentials() promise
+     */
+    _handle2FA(res: any): void;
+    /**
+     * Internal: Helper function to get 2FA code from user and passing it to accept function or skipping account if desired
+     */
+    _get2FAUserInput(): void;
+    /**
+     * Internal: Helper function to make accepting and re-requesting invalid steam guard codes easier
+     * @param code - Input from user
+     */
+    _acceptSteamGuardCode(code: string): void;
+    /**
+     * Helper function to make handling login errors easier
+     * @param err - Error thrown by startWithCredentials()
+     */
+    _handleCredentialsLoginError(err: any): void;
+    /**
+     * Internal - Attempts to get a token for this account from tokens.db and checks if it's valid
+     */
+    _getTokenFromStorage(callback: any): void;
+    /**
+     * Internal - Saves a new token for this account to tokens.db
+     * @param token - The refreshToken to store
+     */
+    _saveTokenToStorage(token: string): void;
+    /**
+     * Remove the token of this account from tokens.db. Intended to be called from the steam-user login error event when an invalid token was used so the next login attempt will create a new one.
+     */
+    invalidateTokenInStorage(): void;
 }
+
+/**
+ * Provide function to only once attach listeners to parent process
+ * @param callback - Called on completion
+ */
+declare function attachParentListeners(callback: (...params: any[]) => any): void;
+
+/**
+ * Provide function to detach parent process event listeners
+ */
+declare function detachParentListeners(): void;
+
+/**
+ * Provide function to attach listeners to make communicating with child possible
+ */
+declare function attachChildListeners(): void;
 
 /**
  * Checks if the needed file exists and gets it if it doesn't
@@ -1219,12 +1209,7 @@ declare class SessionHandler {
  * @param force - If set to true the function will skip checking if the file exists and overwrite it.
  * @returns Resolves when file was successfully loaded
  */
-declare function checkAndGetFile(
-  file: string,
-  logger: (...params: any[]) => any,
-  norequire: boolean,
-  force: boolean
-): Promise<undefined | string | object>;
+declare function checkAndGetFile(file: string, logger: (...params: any[]) => any, norequire: boolean, force: boolean): Promise<undefined | string | object>;
 
 /**
  * Run the application. This function is called by start.js
@@ -1249,14 +1234,9 @@ declare function runCompatibility(controller: Controller): Promise<void | null>;
  * @param datafile - The current `data.json` file from the DataManager
  * @param branch - Which branch you want to check. Defaults to the current branch set in `data.json`
  * @param forceUpdate - If true an update will be forced, even if disableAutoUpdate is true or the newest version is already installed
- * @param [callback] - Called with `updateFound` (Boolean) and `data` (Object) on completion. `updatefound` will be false if the check should fail. `data` includes the full data.json file found online.
+ * @param callback - Called with `updateFound` (Boolean) and `data` (Object) on completion. `updatefound` will be false if the check should fail. `data` includes the full data.json file found online.
  */
-declare function check(
-  datafile: any,
-  branch: string,
-  forceUpdate: boolean,
-  callback?: (...params: any[]) => any
-): void;
+declare function check(datafile: any, branch: string, forceUpdate: boolean, callback: (...params: any[]) => any): void;
 
 /**
  * Run the application. This function is called by start.js
@@ -1272,13 +1252,7 @@ declare function run(): void;
  * @param callback - Legacy param, is unused
  * @returns Resolves when we can proceed
  */
-declare function customUpdateRules(
-  compatibilityfeaturedone: any,
-  oldconfig: any,
-  oldadvancedconfig: any,
-  olddatafile: any,
-  callback: (...params: any[]) => any
-): Promise<void>;
+declare function customUpdateRules(compatibilityfeaturedone: any, oldconfig: any, oldadvancedconfig: any, olddatafile: any, callback: (...params: any[]) => any): Promise<void>;
 
 /**
  * Downloads all files from the repository and installs them
@@ -1302,17 +1276,13 @@ declare function run(): void;
  * @param controller - Reference to the controller object
  */
 declare class Updater {
-  constructor(controller: Controller);
-  /**
-   * Checks for any available update and installs it.
-   * @param forceUpdate - If true an update will be forced, even if disableAutoUpdate is true or the newest version is already installed
-   * @param respondModule - If defined, this function will be called with the result of the check. This allows to integrate checking for updates into commands or plugins. Passes resInfo and txt as parameters.
-   * @param resInfo - Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
-   * @returns Promise that will be resolved with false when no update was found or with true when the update check or download was completed. Expect a restart when true was returned.
-   */
-  run(
-    forceUpdate: boolean,
-    respondModule: (...params: any[]) => any,
-    resInfo: any
-  ): Promise<boolean>;
+    constructor(controller: Controller);
+    /**
+     * Checks for any available update and installs it.
+     * @param forceUpdate - If true an update will be forced, even if disableAutoUpdate is true or the newest version is already installed
+     * @param respondModule - If defined, this function will be called with the result of the check. This allows to integrate checking for updates into commands or plugins. Passes resInfo and txt as parameters.
+     * @returns Promise that will be resolved with false when no update was found or with true when the update check or download was completed. Expect a restart when true was returned.
+     */
+    run(forceUpdate: boolean, respondModule: (...params: any[]) => any, resInfo: any): Promise<boolean>;
 }
+


### PR DESCRIPTION
This PR removes the `steamID64` parameter from the `runCommand` function signature to match https://github.com/3urobeat/steam-comment-service-bot/pull/195  

A resInfo object typedef was also added as this now contains the more or less mandatory `userID` parameter.  
